### PR TITLE
AVOID EXPIRATION OF SESSION TOKENS

### DIFF
--- a/app/com/baasbox/configuration/Application.java
+++ b/app/com/baasbox/configuration/Application.java
@@ -2,9 +2,21 @@ package com.baasbox.configuration;
 
 import play.Logger;
 
+import com.baasbox.security.ISessionTokenProvider;
+import com.baasbox.security.SessionTokenProvider;
+
 
 public enum Application implements IProperties{
-	APPLICATION_NAME("application.name", "The BaasBox served App name", String.class),
+	APPLICATION_NAME("application.name", "The served App name", String.class),
+	SESSION_TOKENS_TIMEOUT("session_tokens.timeout", "The expiration time of the session tokens (in minutes). WARNING: the admin console refreshs the session token every 5 minutes, if you set a value less then 5, you may experience disconnection from the console. To disable expiration set it to 0", Integer.class,
+			//this callback function is invoked when the value changes. It sets the timeout for the session tokens
+			new IPropertyChangeCallback(){
+				public void change(final Object iCurrentValue, final Object iNewValue){
+					ISessionTokenProvider stp = SessionTokenProvider.getSessionTokenProvider();
+					stp.setTimeout(Integer.parseInt(iNewValue.toString())*60000);
+				}
+			}),
+
 	NETWORK_HTTP_SSL("network.http.ssl", "Set to TRUE if the BaasBox server is reached via SSL through a reverse proxy.", Boolean.class),	
 	NETWORK_HTTP_URL("network.http.url", "The public url of the BaasBox server. I.e. the url used by the App to contact BaasBox, without the protocol prefix (i.e. http://) and PORT", String.class),
 	NETWORK_HTTP_PORT("network.http.port", "The public TCP port used by the App to contact BaasBox. Note: this could be different by the port used by BaasBox, if it is behind a reverse proxy", Integer.class);	
@@ -31,6 +43,7 @@ public enum Application implements IProperties{
 	public void setValue(Object newValue) {
 	    Object parsedValue=null;
 
+	    Logger.debug("New setting value, key: " + this.key + ", type: "+ this.type + ", new value: " + newValue);
 	    if (newValue != null)
 	      if (type == Boolean.class)
 	    	  parsedValue = Boolean.parseBoolean(newValue.toString());

--- a/app/com/baasbox/configuration/PropertiesConfigurationHelper.java
+++ b/app/com/baasbox/configuration/PropertiesConfigurationHelper.java
@@ -201,7 +201,7 @@ public class PropertiesConfigurationHelper {
 		try {
 			en.getMethod("setValue",Object.class).invoke(enumValue,value);
 		} catch (Exception e) {
-			throw new ConfigurationException ("Invalid key -" +iKey+ "- or value -" +value  ,e );
+			throw new ConfigurationException ("Invalid key -" +iKey+ "- or value -" +value+"-"  ,e );
 		}
 	}	//setByKey
 	

--- a/app/com/baasbox/controllers/actions/filters/UserCredentialWrapFilter.java
+++ b/app/com/baasbox/controllers/actions/filters/UserCredentialWrapFilter.java
@@ -69,6 +69,7 @@ public class UserCredentialWrapFilter extends Action.Simple {
 		WrapResponse wr = new WrapResponse();
 		Result result=wr.wrap(ctx, tempResult);
 				
+		Logger.debug(result.toString());
 		Logger.trace("Method End");
 	    return result;
 	}

--- a/app/com/baasbox/dao/IndexDao.java
+++ b/app/com/baasbox/dao/IndexDao.java
@@ -33,9 +33,12 @@ public abstract class IndexDao {
 	}
 	
 	public Object get (String key){
-		ORID rid = (ORID) index.get(key);
-		if (rid==null) return null;
-		ODocument value = db.load(rid);
+		ODocument value=null;
+		Object valueOnDb=index.get(key);
+		if (valueOnDb==null) return null;
+		if (valueOnDb instanceof ORID)
+			value = db.load((ORID)valueOnDb);
+		else value=(ODocument)valueOnDb;
 		return value.field("value");
 	}
 }

--- a/conf/configuration.conf
+++ b/conf/configuration.conf
@@ -1,5 +1,6 @@
 [Application]
 application.name=BaasBox
+session_tokens.timeout=0
 network.http.ssl=false
 network.http.url=localhost
 network.http.port=9000

--- a/public/console/bbjs/baasboxgui.js
+++ b/public/console/bbjs/baasboxgui.js
@@ -1188,8 +1188,8 @@ function DocumentsController($scope){
 				         console.log(data);
 				         console.log("sessionStorage.sessionToken: " + sessionStorage.sessionToken);
 						 callMenu("#dashboard");
-						 //refresh the sessiontoken every 14 minutes
-						 refreshSessionToken=setInterval(BBRoutes.com.baasbox.controllers.Generic.refreshSessionToken().ajax(),840000);
+						 //refresh the sessiontoken every 5 minutes
+						 refreshSessionToken=setInterval(BBRoutes.com.baasbox.controllers.Generic.refreshSessionToken().ajax(),300000);
 						 var scope=$("#loggedIn").scope();
 						 scope.$apply(function(){
 						   	 scope.loggedIn=true;


### PR DESCRIPTION
Now the administrator can, via specific setting, set how long a token is valid before expiration.
Setting this value to 0 disable the tokens expiration.
The value is now 0.
