### PR TITLE
use hazelcast for session token management

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -22,7 +22,8 @@ object ApplicationBuild extends Build {
                 "org.scribe" % "scribe" % "1.3.2",
 				"com.eaio.uuid" % "uuid" % "3.4",
 				"org.apache.tika" % "tika-core" % "1.4",
-				"org.apache.tika" % "tika-parsers" % "1.4"
+				"org.apache.tika" % "tika-parsers" % "1.4",
+				"com.hazelcast" % "hazelcast" % "3.1.6"
     		//	,"com.wordnik" %% "swagger-play2" % "1.2.1-SNAPSHOT",
     		//	"com.wordnik" %% "swagger-play2-utils" % "1.2.1-SNAPSHOT",
 


### PR DESCRIPTION
Implemented session token replication with Hazelcast for #249.
It uses the default Hazelcast configuration.

To test it you can start 2 BaasBox instances (use -Dhttp.port to change the default port). Currently you have to create the same user with the same password on each instance because OrientDB is not replicated yet. After that you can login on one instance and use the session token on the other instance.
