### PR TITLE
Documents.delete not working fix

### DIFF
--- a/conf/scripts/baasbox/core.js
+++ b/conf/scripts/baasbox/core.js
@@ -394,7 +394,7 @@ Documents.remove = function(coll,id){
                      name: 'delete',
                      params: {
 
-                         collection: 'collection',
+                         collection: coll,
                          id: id
                      }});
 };


### PR DESCRIPTION
Replaced hard-coded string with variable that should be passed, saw the error when making some scripts via plugin engine.