### PR TITLE
Fixed Document list error when using reverse proxy and HTTPS. Also clarified dependencies on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Further information can be found at [www.baasbox.com](http://www.baasbox.com/ "B
 Build BaasBox
 -------------
 ### Prerequisites
-To build and run BaasBox you need a JDK (not JRE!) (version 8) ([download here](http://www.oracle.com/technetwork/java/javase/downloads/index.html)) and the Play! Framework 2.2.4 ([download here](http://www.playframework.org/download))
+To build and run BaasBox you need a JDK (not JRE!) (version 8) ([download here](http://www.oracle.com/technetwork/java/javase/downloads/index.html)) and the Play! Framework 2.2.4 ([download here](http://www.playframework.org/download)).
+
+*Important*: You must have Play! Framework 2.2.4 installed! BaasBox will not build with other versions.
 
 Once you have installed the above software following, you will be able to build BaasBox.
 

--- a/public/console/bbjs/documents-datatable.js
+++ b/public/console/bbjs/documents-datatable.js
@@ -6,7 +6,7 @@ var documentDataArray= new Array();
 
    function loadDocumentsData(collectionName){
 	   if (collectionName!=null){
-	    	url=BBRoutes.com.baasbox.controllers.Document.getDocuments(collectionName).absoluteURL();
+	    	url = window.location.origin + BBRoutes.com.baasbox.controllers.Document.getDocuments(collectionName).url;
 	    	loadTable($('#documentTable'),documentsDataTableDef,url,documentDataArray); //defined in datatable.js
    		}
     }


### PR DESCRIPTION
Because absoluteURL() was being used to set the URL, using HTTPS and a
reverse proxy was causing errors when retrieving a list of documents. A
temporary fix could be using window.location.origin, but a better way
would be to utilize the configuration file and get the URL and port to
correctly set the URL (for Documents and any other places where
absoluteURL is being used).