### PR TITLE
Generic Responses

### DIFF
--- a/app/com/baasbox/controllers/User.java
+++ b/app/com/baasbox/controllers/User.java
@@ -203,10 +203,12 @@ public class User extends Controller {
 			return badRequest("One or more profile sections is not a valid JSON object");
 		} catch (UserAlreadyExistsException e){
 			if (BaasBoxLogger.isDebugEnabled()) BaasBoxLogger.debug("signUp", e);
-			return badRequest(username + " already exists");
+            // Return a generic error message if the username is already in use.
+			return badRequest("Error signing up");
 		} catch (EmailAlreadyUsedException e){
+            // Return a generic error message if the email is already in use.
 			if (BaasBoxLogger.isDebugEnabled()) BaasBoxLogger.debug("signUp", e);
-			return badRequest(username + ": the email provided is already in use");
+			return badRequest("Error signing up");
 		} catch (Throwable e){
 			BaasBoxLogger.warn("signUp", e);
 			if (Play.isDev()) return internalServerError(ExceptionUtils.getFullStackTrace(e));

--- a/app/com/baasbox/dao/UserDao.java
+++ b/app/com/baasbox/dao/UserDao.java
@@ -84,7 +84,7 @@ public class UserDao extends NodeDao  {
 
 	public ODocument create(String username, String password, String role) throws UserAlreadyExistsException {
 		OrientGraph db = DbHelper.getOrientGraphConnection();
-		if (existsUserName(username)) throw new UserAlreadyExistsException("User " + username + " already exists");
+		if (existsUserName(username)) throw new UserAlreadyExistsException("Error signing up");
 		OUser user=null;
 		if (role==null) user=db.getRawGraph().getMetadata().getSecurity().createUser(username,password,new String[]{DefaultRoles.REGISTERED_USER.toString()});
 		else {


### PR DESCRIPTION
Remove information from certain responses that could be used for user
enumeration. For example, signing up with an email that has already
been used previously told the attacker that this was the case.