### PR TITLE
Invalid criteria management

### DIFF
--- a/app/com/baasbox/dao/NodeDao.java
+++ b/app/com/baasbox/dao/NodeDao.java
@@ -33,6 +33,7 @@ import com.baasbox.service.logging.BaasBoxLogger;
 import com.baasbox.service.storage.BaasBoxPrivateFields;
 import com.baasbox.util.QueryParams;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.orientechnologies.orient.core.command.OCommandManager;
 import com.orientechnologies.orient.core.command.OCommandRequest;
 import com.orientechnologies.orient.core.db.record.ODatabaseRecordTx;
 import com.orientechnologies.orient.core.exception.OCommandExecutionException;
@@ -187,7 +188,24 @@ public abstract class NodeDao  {
 	}
 	
 
-
+	public Object explainQuery(QueryParams criteria) throws SqlInjectionException{
+		try{
+			OCommandRequest command = DbHelper.genericSQLStatementCommandBuilder("explain " + DbHelper.selectQueryBuilder(MODEL_NAME, false, criteria));
+			Object toRet = DbHelper.genericSQLCommandExecute(command, criteria.getParams());
+			return toRet;
+		}catch (OCommandExecutionException e ){
+			throw new InvalidCriteriaException("Invalid criteria. Please check if your querystring is encoded in a corrected way. Double check the single-quote and the quote characters",e);
+		}catch (OQueryParsingException e ){
+			throw new InvalidCriteriaException("Invalid criteria. Please check if your querystring is encoded in a corrected way. Double check the single-quote and the quote characters",e);
+		}catch (OCommandSQLParsingException e){
+			throw new InvalidCriteriaException(e);
+		}catch (StringIndexOutOfBoundsException e){
+			throw new InvalidCriteriaException("Invalid criteria. Please check your query, the syntax and the parameters",e);
+		}catch (IndexOutOfBoundsException e){
+			throw new InvalidCriteriaException("Invalid criteria. Please check your query, the syntax and the parameters",e);
+		}
+	}
+	
 	public List<ODocument> get(QueryParams criteria) throws SqlInjectionException, InvalidCriteriaException {
 		if (BaasBoxLogger.isTraceEnabled()) BaasBoxLogger.trace("Method Start");
 		List<ODocument> result = null;

--- a/app/com/baasbox/db/hook/Audit.java
+++ b/app/com/baasbox/db/hook/Audit.java
@@ -77,13 +77,14 @@ public class Audit extends BaasBoxHook {
 					 ( doc.field("type")==null )
 					){
 					if(!doc.isEmbedded() && doc.getClassName()!=null && doc.getSchemaClass().isSubClassOf(NodeDao.CLASS_NODE_NAME)){
-						if (BaasBoxLogger.isDebugEnabled()) BaasBoxLogger.debug("  AuditHook.onRecordBeforeUpdate: update of audit fields for ORecord: " + iRecord.getIdentity());
+						if (BaasBoxLogger.isDebugEnabled()) BaasBoxLogger.debug("  AuditHook.onRecordBeforeUpdate: update of audit fields for ORecord:{} " , iRecord.getIdentity());
 						ODocument auditDoc = doc.field(BBInternalConstants.FIELD_AUDIT);
 						if (auditDoc==null) auditDoc = new ODocument();
 						Date data = new Date();
 						auditDoc.field("modifiedBy",iRecord.getDatabase().getUser().getDocument().getIdentity());
 						auditDoc.field("modifiedOn",data);
 						doc.field(BBInternalConstants.FIELD_AUDIT,auditDoc);	
+						if (BaasBoxLogger.isDebugEnabled()) BaasBoxLogger.debug("  AuditHook.onRecordBeforeUpdate: update of audit fields for ORecord: {} done." , iRecord.getIdentity());
 						return RESULT.RECORD_CHANGED;
 					}
 				}

--- a/app/com/baasbox/service/storage/DocumentService.java
+++ b/app/com/baasbox/service/storage/DocumentService.java
@@ -309,4 +309,14 @@ public class DocumentService {
         return rid;
     }
 
+	public static boolean checkSyntax(String collectionName, QueryParams criteria) throws InvalidCollectionException, SqlInjectionException {
+		QueryParams checkCriteria = criteria.clone();
+		checkCriteria.page(0);
+		checkCriteria.recordPerPage(1);
+		checkCriteria.disablePaginationMore();
+		DocumentDao dao = DocumentDao.getInstance(collectionName);
+		dao.explainQuery(checkCriteria); //this is a trick to force the parser to evaluate the query
+		return true;
+	}
+
 }

--- a/app/com/baasbox/util/QueryParams.java
+++ b/app/com/baasbox/util/QueryParams.java
@@ -27,7 +27,6 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.baasbox.BBConfiguration;
-
 import com.baasbox.service.logging.BaasBoxLogger;
 
 
@@ -44,6 +43,36 @@ public class QueryParams implements IQueryParametersKeys{
 	private Object[] params={};
 	private boolean more = false;
 
+
+	@Override
+	public QueryParams clone(){
+		QueryParams cloned = QueryParams.getInstance();
+		cloned.justCountTheRecords(this.justCount);
+		cloned.fields(this.fields);
+		cloned.where(this.where);
+		cloned.page(this.page);
+		cloned.skip(this.skip);
+		cloned.recordPerPage(this.recordPerPage);
+		cloned.groupBy(this.groupBy);
+		cloned.orderBy(this.orderBy);
+		cloned.depth(this.depth);
+		cloned.params(this.params);
+		if (this.more) cloned.enablePaginationMore();
+		else cloned.disablePaginationMore();
+		return cloned;
+	}
+	
+	public void recordPerPage(Integer recordPerPage) {
+		this.recordPerPage=recordPerPage;
+	}
+	
+	public void depth(Integer depth) {
+		this.depth=depth;
+	}
+
+	public void page(Integer page) {
+		this.page = page;
+	}
 
 	protected QueryParams(){};
 	

--- a/test/DocumentListChunkedBadSyntaxTest.java
+++ b/test/DocumentListChunkedBadSyntaxTest.java
@@ -1,0 +1,107 @@
+/*
+     Copyright 2012-2013 
+     Claudio Tesoriero - c.tesoriero-at-baasbox.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// @author: Marco Tibuzzi
+
+import static play.test.Helpers.GET;
+import static play.test.Helpers.HTMLUNIT;
+import static play.test.Helpers.route;
+import static play.test.Helpers.running;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.http.HttpHeaders;
+import org.junit.Before;
+import org.junit.Test;
+
+import play.libs.F.Callback;
+import play.mvc.Http.Status;
+import play.mvc.Result;
+import play.mvc.SimpleResult;
+import play.test.FakeRequest;
+import play.test.TestBrowser;
+import core.AbstractDocumentTest;
+import core.TestConfig;
+
+
+public class DocumentListChunkedBadSyntaxTest extends AbstractDocumentTest
+{
+	protected String sFakeCollection;
+
+
+	@Override
+	public String getRouteAddress()
+	{
+		return DocumentCMDFunctionalTest.SERVICE_ROUTE + TestConfig.TEST_COLLECTION_NAME;
+	}
+	
+	@Override
+	public String getMethod()
+	{
+		return GET;
+	}
+	
+	@Override
+	protected void assertContent(String s)
+	{
+		Object json = toJSON(s);
+		assertJSON(json, "@rid");
+	}
+
+
+	@Before
+	public void beforeTest()
+	{
+		running
+		(
+			getTestServerWithChunkResponse(), 
+			HTMLUNIT, 
+			new Callback<TestBrowser>() 
+	        {
+				public void invoke(TestBrowser browser) 
+				{
+					 sFakeCollection = new AdminCollectionFunctionalTest().serverCreateCollection();
+				}
+	        }
+		);
+	}
+	
+	
+	@Test
+	public void testServerListBadSyntaxChunked()
+	{
+		running
+		(
+			getTestServerWithChunkResponse(), 
+			HTMLUNIT, 
+			new Callback<TestBrowser>() 
+	        {
+				public void invoke(TestBrowser browser) 
+				{
+					// Test bad where
+					setHeader(TestConfig.KEY_APPCODE, TestConfig.VALUE_APPCODE);
+					setHeader(TestConfig.KEY_AUTH, TestConfig.AUTH_ADMIN_ENC);
+					setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED);
+					httpRequest(getURLAddress(sFakeCollection)+"?where=in%20(p)", getMethod());
+					assertServer("testServerListBadSyntaxChunked bad where", Status.BAD_REQUEST, "\"result\":\"error\"", true);
+				}
+	        }
+		);
+	}
+	
+
+}

--- a/test/DocumentListNoChunkedBadSyntaxTest.java
+++ b/test/DocumentListNoChunkedBadSyntaxTest.java
@@ -1,0 +1,106 @@
+/*
+     Copyright 2012-2013 
+     Claudio Tesoriero - c.tesoriero-at-baasbox.com
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// @author: Marco Tibuzzi
+
+import static play.test.Helpers.GET;
+import static play.test.Helpers.HTMLUNIT;
+import static play.test.Helpers.route;
+import static play.test.Helpers.running;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.http.HttpHeaders;
+import org.junit.Before;
+import org.junit.Test;
+
+import play.libs.F.Callback;
+import play.mvc.Http.Status;
+import play.mvc.Result;
+import play.mvc.SimpleResult;
+import play.test.FakeRequest;
+import play.test.TestBrowser;
+import core.AbstractDocumentTest;
+import core.TestConfig;
+
+
+public class DocumentListNoChunkedBadSyntaxTest extends AbstractDocumentTest
+{
+	protected String sFakeCollection;
+
+
+	@Override
+	public String getRouteAddress()
+	{
+		return DocumentCMDFunctionalTest.SERVICE_ROUTE + TestConfig.TEST_COLLECTION_NAME;
+	}
+	
+	@Override
+	public String getMethod()
+	{
+		return GET;
+	}
+	
+	@Override
+	protected void assertContent(String s)
+	{
+		Object json = toJSON(s);
+		assertJSON(json, "@rid");
+	}
+
+
+	@Before
+	public void beforeTest()
+	{
+		running
+		(
+			getTestServer(), 
+			HTMLUNIT, 
+			new Callback<TestBrowser>() 
+	        {
+				public void invoke(TestBrowser browser) 
+				{
+					 sFakeCollection = new AdminCollectionFunctionalTest().serverCreateCollection();
+				}
+	        }
+		);
+	}
+	
+	
+	@Test
+	public void testServerListBadSyntaxChunked()
+	{
+		running
+		(
+			getTestServer(), 
+			HTMLUNIT, 
+			new Callback<TestBrowser>() 
+	        {
+				public void invoke(TestBrowser browser) 
+				{
+					// Test bad where
+					setHeader(TestConfig.KEY_APPCODE, TestConfig.VALUE_APPCODE);
+					setHeader(TestConfig.KEY_AUTH, TestConfig.AUTH_ADMIN_ENC);
+					setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED);
+					httpRequest(getURLAddress(sFakeCollection)+"?where=in%20(p)", getMethod());
+					assertServer("testServerListBadSyntaxChunked bad where", Status.BAD_REQUEST, "\"result\":\"error\"", true);
+				}
+	        }
+		);
+	}
+	
+}


### PR DESCRIPTION
With the new implementation of chunked responses a new bug was introduced as well.
If one query criteria was invalid (an invalid where condition), the server replied 200 OK, and then output the error.
Now the query is parsed before its execution.