### PR TITLE
Fix outdated dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/java:oracle-java8
+FROM java:8
 MAINTAINER Cesare Rocchi <c.rocchi@baasbox.com>
 WORKDIR /baasbox
 


### PR DESCRIPTION
Use updated Docker Java repository. OpenJDK 8 is used.

Refer to the migration here: [http://blog.docker.com/2015/03/updates-available-to-popular-repos-update-your-images/](http://blog.docker.com/2015/03/updates-available-to-popular-repos-update-your-images/)