### PR TITLE
Add support for Layer chat API

### DIFF
--- a/app/com/baasbox/configuration/Application.java
+++ b/app/com/baasbox/configuration/Application.java
@@ -39,7 +39,13 @@ public enum Application implements IProperties{
 
 	NETWORK_HTTP_SSL("network.http.ssl", "Set to TRUE if the BaasBox server is reached via SSL through a reverse proxy.", Boolean.class),	
 	NETWORK_HTTP_URL("network.http.url", "The public url of the BaasBox server. I.e. the url used by the App to contact BaasBox, without the protocol prefix (i.e. http://) and PORT", String.class),
-	NETWORK_HTTP_PORT("network.http.port", "The public TCP port used by the App to contact BaasBox. Please note: when behind a reverse proxy, this could be different from the port used by BaasBox.", Integer.class);	
+	NETWORK_HTTP_PORT("network.http.port", "The public TCP port used by the App to contact BaasBox. Please note: when behind a reverse proxy, this could be different from the port used by BaasBox.", Integer.class),
+
+	LAYER_API_PRIVATE_KEY("layerapi.private.key","Layer API private key",String.class),
+	LAYER_API_PROVIDER_ID("layerapi.provider.id","Layer API provider (ie: layer:///providers/XXXX-XXX)", String.class),
+	LAYER_API_ENABLED("layerapi.link.enabled","Layer API link enable flag", Boolean.class),
+    LAYER_API_KEY_ID("layerapi.key.id","Layer API key id (ie: layer:///keys/XXXX-XXX)", String.class),
+;
 	
 	private final String                 key;
 	private final Class<?>               type;

--- a/app/com/baasbox/service/sociallogin/NonceServiceToken.java
+++ b/app/com/baasbox/service/sociallogin/NonceServiceToken.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2015.
+ *
+ * BaasBox - info-at-baasbox.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package com.baasbox.service.sociallogin;
+
+import com.baasbox.configuration.Application;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.Signature;
+import java.util.Base64;
+import java.util.Date;
+import org.bouncycastle.openssl.PEMReader;
+
+public class NonceServiceToken {
+	
+	private static final String DEFAULT_LAYER_PRIVATE_KEY = "";
+	private static final String DEFAULT_LAYER_PROVIDER_ID = "";
+	private static final String DEFAULT_LAYER_KEY_ID = "";
+
+    public static String getHexString(byte[] b) throws Exception {
+        String result = "";
+        for (int i=0; i < b.length; i++) {
+            result +=
+                Integer.toString( ( b[i] & 0xff ) + 0x100, 16).substring( 1 );
+        }
+        return result;
+    }
+
+    private KeyPair GetKeyPairFromPKCSKey(String key) throws Exception {
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        Reader fRd = new StringReader(key);
+        try {
+        	PEMReader pemReader = new PEMReader(fRd);
+        	KeyPair pair = (KeyPair)pemReader.readObject();
+        	pemReader.close();
+        	return pair;
+        } catch (Exception ex) {
+        	throw ex;
+        }
+    }
+    
+    private String GetSHA256 (String text, PrivateKey privateKey) throws Exception {
+            Signature signature = Signature.getInstance("SHA256withRSA","BC");
+            signature.initSign(privateKey);
+            signature.update(text.getBytes());      
+            byte[] data = signature.sign();
+            String hexString = getHexString(data);
+            return hexString;
+    }
+    
+	public String GetNonceToken(String username, String nonce) throws Exception {
+		String token = "";
+
+		/* LOAD LAYER PARAMETERS */
+		String layerProviderID = Application.LAYER_API_PROVIDER_ID.getValueAsString();
+	    String layerKeyID = Application.LAYER_API_KEY_ID.getValueAsString();
+	    String layerPrivateKey = Application.LAYER_API_PRIVATE_KEY.getValueAsString();
+
+    	layerProviderID = (layerProviderID == null) ? DEFAULT_LAYER_PROVIDER_ID : layerProviderID;
+    	layerKeyID = (layerKeyID == null) ? DEFAULT_LAYER_KEY_ID : layerKeyID;
+    	layerPrivateKey = (layerPrivateKey == null) ? DEFAULT_LAYER_PRIVATE_KEY : layerPrivateKey;
+    
+    	// Read key from PEM (---- BEGIN RSA .... key format)
+    	KeyPair pair = GetKeyPairFromPKCSKey(layerPrivateKey);
+    	
+    	/* CREATE HEADER AND SHA256*/
+    	String header = "{\"typ\":\"JWT\",\"alg\":\"RS256\",\"cty\":\"layer-eit;v=1\",\"kid\":\"" + layerKeyID + "\"}";
+    	String h = Base64.getEncoder().encodeToString(header.getBytes());
+
+    	/* CREATE CLAIM AND SH 256 */
+    	long currentTimeInSeconds = Math.round(new Date().getTime() / 1000);
+    	long expirationTime = currentTimeInSeconds + 10000;
+    	
+    	// DEBUG ONLY    	
+    	String claim = "{\"iss\":\"" + layerProviderID + "\",\"prn\":\"" + username + "\",\"iat\":" + currentTimeInSeconds + ",\"exp\":" + expirationTime + ",\"nce\":\"" + nonce + "\"}";
+    	String c = Base64.getEncoder().encodeToString(claim.getBytes());
+    	    	
+    	/* CREATE JWT FOR LAYER*/
+    	String n = h + "." + c;
+    	String nSha = GetSHA256(n, pair.getPrivate());
+    	token = n + "." + nSha;
+    	
+		return Base64.getEncoder().encodeToString(token.getBytes());
+		    
+	}
+}
+

--- a/conf/configuration.conf
+++ b/conf/configuration.conf
@@ -4,6 +4,10 @@ session_tokens.timeout=0
 network.http.ssl=false
 network.http.url=localhost
 network.http.port=9000
+layerapi.private.key=PEM key (---- BEGIN RSA PRIVATE KEY -----)
+layerapi.provider.id=layer:///
+layerapi.link.enabled=false
+layerapi.key.id=layer:///
 
 [PasswordRecovery]
 network.smtp.host=mail.example.com

--- a/conf/routes
+++ b/conf/routes
@@ -68,6 +68,8 @@ POST	/logout/:pushToken	    			com.baasbox.controllers.User.logoutWithDevice(pus
 # @tag(baasbox.account)
 POST 	/logout								com.baasbox.controllers.User.logoutWithoutDevice()
 
+# @tag(baasbox.account)
+POST	/generateLayerToken					com.baasbox.controllers.User.generateLayerToken()
 
 # @tag(baasbox.social)
 GET		/social		    		    				com.baasbox.controllers.Social.socialLogins()


### PR DESCRIPTION
Generates SHA256 signed token for authentication with Layer chat
services. For further info check layer.com.

Example of use:
curl -X POST http://localhost:9000/generateLayerToken -d '{"nonce" : "$nonce"}' -H "X-BB-SESSION:$sessionID" -H X-BAASBOX-APPCODE:1234567890 -H Content-type:application/json