### PR TITLE
Facebook API since v2.4 requires explicit fields for /me request.

### DIFF
--- a/app/com/baasbox/service/sociallogin/FacebookLoginService.java
+++ b/app/com/baasbox/service/sociallogin/FacebookLoginService.java
@@ -69,7 +69,7 @@ public class FacebookLoginService extends SocialLoginService{
 
 	@Override
 	public String userInfoUrl() {
-		return "https://graph.facebook.com/me";
+		return "https://graph.facebook.com/me?fields=id,email,gender,link,name";
 	}
 
 	


### PR DESCRIPTION
Facebook API since v2.4 requires explicit fields for /me request.
https://stackoverflow.com/questions/32584850/facebook-js-sdks-fb-api-me-method-doesnt-return-the-fields-i-expect-in-gra
https://developers.facebook.com/docs/apps/changelog#v2_4

From https://github.com/baasbox/baasbox/pull/946#issuecomment-223633717
