### PR TITLE
removed old image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/java:oracle-java8
+FROM java:8
 MAINTAINER Cesare Rocchi <c.rocchi@baasbox.com>
 WORKDIR /baasbox
 
@@ -9,3 +9,4 @@ RUN mv baasbox-*/ baasbox/
 RUN chmod +x baasbox/start
 EXPOSE 9000
 ENTRYPOINT baasbox/start
+h


### PR DESCRIPTION
Dockerfile repo and images are no longer available, if you are interested in the reason why it is documented on Docker Hub's blog.
Also oracle-java is not available either same as the dependent Ubuntu server.

So the new java image has been renamed to java:version eg: java:8 it is also now using OpenJDK.

I've tested this image and it works fine.

If you want to use Oracle Java then you have to build your own image and replace the FROM statement to point to your image.
